### PR TITLE
Avoid estimating trading costs for tiny rebalances

### DIFF
--- a/v2/execution.py
+++ b/v2/execution.py
@@ -17,6 +17,8 @@ class OrderPlan:
 
 def estimate_cost_bps(delta_notional: float, price: float, adv: float,
                       spread_bps: float, kappa: float, psi: float) -> float:
+    if abs(delta_notional) <= 1e-6:
+        return 0.0
     if price <= 0 or adv <= 0:
         return abs(spread_bps)
     qty = abs(delta_notional) / price


### PR DESCRIPTION
## Summary
- guard estimate_cost_bps against effectively zero notionals so the cost gate ignores float noise

## Testing
- python run_v2.py

------
https://chatgpt.com/codex/tasks/task_e_68dcab29eb008331a14c1f868fb81c11