### PR TITLE
Add richer episode context logging and dashboard updates

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -55,6 +55,10 @@
           <div class="metric-value text-danger">{{ '%.2f'|format(latest.est_cost_bps|default(0)) }} bps</div>
         </div>
         <div class="col-sm-6 col-lg-3">
+          <div class="metric-label">Net edge</div>
+          <div class="metric-value text-success">{{ '%.2f'|format(latest.net_edge_bps|default(0)) }} bps</div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
           <div class="metric-label">Investable</div>
           <div class="metric-value">${{ '%.0f'|format(latest.investable|default(0)) }}</div>
         </div>
@@ -98,6 +102,7 @@
               <th class="text-center">Proceed</th>
               <th class="text-end">Expected α (bps)</th>
               <th class="text-end">Costs (bps)</th>
+              <th class="text-end">Net (bps)</th>
               <th>Orders</th>
             </tr>
           </thead>
@@ -114,6 +119,7 @@
               </td>
               <td class="text-end">{{ '%.2f'|format(ep.expected_alpha_bps|default(0)) }}</td>
               <td class="text-end">{{ '%.2f'|format(ep.est_cost_bps|default(0)) }}</td>
+              <td class="text-end">{{ '%.2f'|format(ep.net_edge_bps|default(0)) }}</td>
               <td>
                 {% if ep.orders_submitted %}
                   {{ ep.orders_submitted|length }}
@@ -124,7 +130,7 @@
             </tr>
             {% else %}
             <tr>
-              <td colspan="5" class="text-center text-muted">No recent activity.</td>
+              <td colspan="6" class="text-center text-muted">No recent activity.</td>
             </tr>
             {% endfor %}
           </tbody>

--- a/templates/log.html
+++ b/templates/log.html
@@ -20,6 +20,7 @@
           <th class="text-center">Proceed</th>
           <th class="text-end">Expected α (bps)</th>
           <th class="text-end">Costs (bps)</th>
+          <th class="text-end">Net (bps)</th>
           <th>Orders</th>
           <th style="min-width: 200px;">Notes</th>
         </tr>
@@ -37,6 +38,7 @@
           </td>
           <td class="text-end">{{ '%.2f'|format(ep.expected_alpha_bps|default(0)) }}</td>
           <td class="text-end">{{ '%.2f'|format(ep.est_cost_bps|default(0)) }}</td>
+          <td class="text-end">{{ '%.2f'|format(ep.net_edge_bps|default(0)) }}</td>
           <td>
             {% if ep.orders_submitted %}
               {{ ep.orders_submitted|length }} ids
@@ -45,13 +47,24 @@
             {% endif %}
           </td>
           <td class="text-muted small">
+            {% set verdict = ep.get('risk_officer_verdict', {}) %}
             {% set risk = ep.get('risk_officer', {}) %}
-            {% if risk.message %}{{ risk.message }}{% elif risk.approved %}Risk officer: {{ risk.approved }}{% else %}—{% endif %}
+            {% set note = verdict.message or risk.get('message') %}
+            {% if note %}
+              {{ note }}
+            {% elif verdict.approved %}
+              Risk officer: approved
+            {% elif risk.approved %}
+              Risk officer: {{ risk.approved }}
+            {% else %}
+              —
+            {% endif %}
+            {% if ep.rebalance_summary %}<br><span class="text-body">Δ {{ ep.rebalance_summary }}</span>{% endif %}
           </td>
         </tr>
         {% else %}
         <tr>
-          <td colspan="6" class="text-center text-muted py-4">No runs recorded yet.</td>
+          <td colspan="7" class="text-center text-muted py-4">No runs recorded yet.</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- capture alpha decomposition, rebalance deltas, and cost details in `run_once` episodes along with a human-readable logging summary
- include risk officer verdict metadata and net edge calculations in the JSONL payload for downstream consumers
- surface the new net edge and decision notes on the dashboard and log tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dccee74a708331afacf9b21b2f6a8b