### PR TITLE
feat: richer logs + higher retention, fix constant cost bps, clearer dashboard (status & gating reasons)

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,6 +5,92 @@
 
 {% block content %}
 <div class="row g-3 mb-4">
+  <div class="col-12 col-xl-4">
+    <div class="card card-surface p-4 h-100">
+      <h6 class="fw-semibold mb-3">Status</h6>
+      <dl class="row small mb-0">
+        <dt class="col-5 text-muted">Mode</dt>
+        <dd class="col-7">{{ status.mode_label }}</dd>
+        <dt class="col-5 text-muted">Automation</dt>
+        <dd class="col-7">{{ 'On' if status.enabled else 'Off' }}</dd>
+        <dt class="col-5 text-muted">Next run</dt>
+        <dd class="col-7">{{ status.next_run }}</dd>
+        <dt class="col-5 text-muted">Model &amp; effort</dt>
+        <dd class="col-7">{{ status.model or '—' }}{% if status.effort %} / {{ status.effort }}{% endif %}</dd>
+      </dl>
+    </div>
+  </div>
+  <div class="col-12 col-xl-4">
+    <div class="card card-surface p-4 h-100">
+      <h6 class="fw-semibold mb-3">Portfolio snapshot</h6>
+      <dl class="row small mb-0">
+        <dt class="col-5 text-muted">Equity</dt>
+        <dd class="col-7">{{ "${:,.0f}".format(portfolio_snapshot.equity) }}</dd>
+        <dt class="col-5 text-muted">Cash</dt>
+        <dd class="col-7">{{ "${:,.0f}".format(portfolio_snapshot.cash) }}</dd>
+        <dt class="col-5 text-muted">Cash %</dt>
+        <dd class="col-7">{{ '%.1f'|format(portfolio_snapshot.cash_pct) }}%</dd>
+        <dt class="col-5 text-muted">Positions</dt>
+        <dd class="col-7">{{ portfolio_snapshot.positions }}</dd>
+        <dt class="col-5 text-muted">Target gross</dt>
+        <dd class="col-7">{{ '%.2f'|format(portfolio_snapshot.target_gross) }}×</dd>
+      </dl>
+    </div>
+  </div>
+  <div class="col-12 col-xl-4">
+    <div class="card card-surface p-4 h-100">
+      <div class="d-flex justify-content-between align-items-start mb-3">
+        <div>
+          <h6 class="fw-semibold mb-1">Last run</h6>
+          {% if latest %}
+          <div class="text-muted small">{{ latest.as_of }}</div>
+          {% else %}
+          <div class="text-muted small">No runs recorded yet</div>
+          {% endif %}
+        </div>
+        <form method="post" action="{{ url_for('run_now') }}">
+          <button type="submit" class="btn btn-primary btn-sm">Run analysis now</button>
+        </form>
+      </div>
+      <p class="mb-3">{{ last_run.summary }}</p>
+      <div class="d-flex flex-wrap gap-3 small">
+        <div>
+          <div class="text-muted">Expected</div>
+          <div class="fw-semibold">{{ '%.1f'|format(last_run.expected_bps) }} bps</div>
+        </div>
+        <div>
+          <div class="text-muted">Cost</div>
+          <div class="fw-semibold">{{ '%.1f'|format(last_run.cost_bps) }} bps</div>
+        </div>
+        {% set last_net_class = 'text-success' if last_run.net_bps > 0 else ('text-danger' if last_run.net_bps < 0 else '') %}
+        <div>
+          <div class="text-muted">Net</div>
+          <div class="fw-semibold {{ last_net_class }}">{{ '%.1f'|format(last_run.net_bps) }} bps</div>
+        </div>
+        <div>
+          <div class="text-muted">Turnover</div>
+          <div class="fw-semibold">{{ '%.1f'|format(last_run.turnover_pct) }}%</div>
+        </div>
+        <div>
+          <div class="text-muted">Orders</div>
+          <div class="fw-semibold">{{ last_run.actual_orders if last_run.traded else last_run.order_count }}</div>
+        </div>
+      </div>
+      {% if last_run.reasons %}
+      <div class="mt-3">
+        <div class="text-muted small mb-1">Gating reasons</div>
+        <div class="d-flex flex-wrap gap-2">
+          {% for reason in last_run.reasons %}
+          <span class="status-pill neutral">{{ reason }}</span>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<div class="row g-3 mb-4">
   <div class="col-6 col-xl-3">
     <div class="card card-surface p-3 h-100">
       <div class="metric-label">Total runs</div>
@@ -20,13 +106,13 @@
   <div class="col-6 col-xl-3">
     <div class="card card-surface p-3 h-100">
       <div class="metric-label">Avg expected α</div>
-      <div class="metric-value">{{ metrics.avg_expected }} bps</div>
+      <div class="metric-value">{{ '%.1f'|format(metrics.avg_expected) }} bps</div>
     </div>
   </div>
   <div class="col-6 col-xl-3">
     <div class="card card-surface p-3 h-100">
       <div class="metric-label">Net projected edge</div>
-      <div class="metric-value">{{ metrics.net_edge }}</div>
+      <div class="metric-value">{{ '%.2f'|format(metrics.net_edge) }}</div>
     </div>
   </div>
 </div>
@@ -35,36 +121,51 @@
   <div class="col-12 col-xl-8">
     <div class="card card-surface p-4 mb-4">
       {% if latest %}
+      {% set gate = latest.get('gate', {}) or {} %}
+      {% set expected = gate.get('expected_alpha_bps', latest.get('expected_alpha_bps', 0)) | float %}
+      {% set cost = gate.get('cost_bps', latest.get('est_cost_bps', 0)) | float %}
+      {% set net = gate.get('net_bps', latest.get('net_edge_bps', 0)) | float %}
+      {% set turnover = gate.get('turnover_pct', 0) | float %}
+      {% set order_count = gate.get('order_count', latest.get('planned_orders_count', 0)) %}
+      {% set net_class = 'text-success' if net > 0 else ('text-danger' if net < 0 else '') %}
       <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
         <div>
-          <h5 class="mb-1">Latest episode</h5>
+          <h5 class="mb-1">Latest run details</h5>
           <div class="text-muted small">{{ latest.as_of }}</div>
         </div>
-        <form method="post" action="{{ url_for('run_now') }}">
-          <button type="submit" class="btn btn-primary">Trigger run</button>
-        </form>
+        <div class="text-lg-end">
+          {% if gate.get('proceed') %}
+          <span class="status-pill"><i class="bi bi-check-circle"></i>Gate: Go</span>
+          {% else %}
+          <span class="status-pill negative"><i class="bi bi-x-circle"></i>Gate: Hold</span>
+          {% endif %}
+        </div>
       </div>
       <hr>
       <div class="row g-3">
         <div class="col-sm-6 col-lg-3">
           <div class="metric-label">Expected α</div>
-          <div class="metric-value text-primary">{{ '%.2f'|format(latest.expected_alpha_bps|default(0)) }} bps</div>
+          <div class="metric-value">{{ '%.1f'|format(expected) }} bps</div>
         </div>
         <div class="col-sm-6 col-lg-3">
           <div class="metric-label">Est. costs</div>
-          <div class="metric-value text-danger">{{ '%.2f'|format(latest.est_cost_bps|default(0)) }} bps</div>
+          <div class="metric-value text-danger">{{ '%.1f'|format(cost) }} bps</div>
         </div>
         <div class="col-sm-6 col-lg-3">
           <div class="metric-label">Net edge</div>
-          <div class="metric-value text-success">{{ '%.2f'|format(latest.net_edge_bps|default(0)) }} bps</div>
+          <div class="metric-value {{ net_class }}">{{ '%.1f'|format(net) }} bps</div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <div class="metric-label">Turnover</div>
+          <div class="metric-value">{{ '%.1f'|format(turnover) }}%</div>
         </div>
         <div class="col-sm-6 col-lg-3">
           <div class="metric-label">Investable</div>
-          <div class="metric-value">${{ '%.0f'|format(latest.investable|default(0)) }}</div>
+          <div class="metric-value">{{ "${:,.0f}".format(latest.investable|default(0)) }}</div>
         </div>
         <div class="col-sm-6 col-lg-3">
-          <div class="metric-label">Orders</div>
-          <div class="metric-value">{{ latest.orders_submitted|length }}</div>
+          <div class="metric-label">Orders planned</div>
+          <div class="metric-value">{{ order_count }}</div>
         </div>
       </div>
       <div class="mt-4">
@@ -82,9 +183,6 @@
       {% else %}
       <div class="text-center py-4">
         <p class="text-muted mb-3">No trading episodes recorded yet.</p>
-        <form method="post" action="{{ url_for('run_now') }}">
-          <button type="submit" class="btn btn-primary">Run the trading engine</button>
-        </form>
       </div>
       {% endif %}
     </div>
@@ -108,24 +206,25 @@
           </thead>
           <tbody>
             {% for ep in episodes %}
+            {% set gate = ep.get('gate', {}) or {} %}
+            {% set expected_ep = gate.get('expected_alpha_bps', ep.get('expected_alpha_bps', 0)) | float %}
+            {% set cost_ep = gate.get('cost_bps', ep.get('est_cost_bps', 0)) | float %}
+            {% set net_ep = gate.get('net_bps', ep.get('net_edge_bps', 0)) | float %}
+            {% set net_class = 'text-success' if net_ep > 0 else ('text-danger' if net_ep < 0 else '') %}
             <tr>
               <td>{{ ep.as_of }}</td>
               <td class="text-center">
-                {% if ep.proceed %}
-                <span class="status-pill"><i class="bi bi-check-circle"></i>Yes</span>
+                {% if gate.get('proceed') %}
+                <span class="status-pill"><i class="bi bi-check-circle"></i>Go</span>
                 {% else %}
-                <span class="status-pill negative"><i class="bi bi-x-circle"></i>No</span>
+                <span class="status-pill negative"><i class="bi bi-x-circle"></i>Hold</span>
                 {% endif %}
               </td>
-              <td class="text-end">{{ '%.2f'|format(ep.expected_alpha_bps|default(0)) }}</td>
-              <td class="text-end">{{ '%.2f'|format(ep.est_cost_bps|default(0)) }}</td>
-              <td class="text-end">{{ '%.2f'|format(ep.net_edge_bps|default(0)) }}</td>
+              <td class="text-end">{{ '%.1f'|format(expected_ep) }}</td>
+              <td class="text-end">{{ '%.1f'|format(cost_ep) }}</td>
+              <td class="text-end"><span class="{{ net_class }}">{{ '%.1f'|format(net_ep) }}</span></td>
               <td>
-                {% if ep.orders_submitted %}
-                  {{ ep.orders_submitted|length }}
-                {% else %}
-                  —
-                {% endif %}
+                {{ gate.get('order_count', ep.get('planned_orders_count', 0)) }}
               </td>
             </tr>
             {% else %}

--- a/templates/log.html
+++ b/templates/log.html
@@ -5,70 +5,115 @@
 
 {% block content %}
 <div class="card card-surface p-4">
-  <div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
     <div>
       <h5 class="fw-semibold mb-1">Episodes history</h5>
-      <p class="text-muted small mb-0">Showing the {{ episodes|length }} most recent runs.</p>
+      <p class="text-muted small mb-0">
+        Page {{ page }}{% if total_pages %} / {{ total_pages }}{% endif %} · showing {{ episodes|length }} runs ({{ start_index }}–{{ end_index }} of {{ total }})
+      </p>
     </div>
-    <a class="btn btn-outline-secondary" href="{{ url_for('dashboard') }}">Back to dashboard</a>
+    <div class="d-flex flex-wrap gap-2">
+      <a class="btn btn-outline-secondary" href="{{ url_for('log_csv') }}">
+        <i class="bi bi-download"></i>
+        Export CSV
+      </a>
+      <a class="btn btn-outline-secondary" href="{{ url_for('dashboard') }}">Back to dashboard</a>
+    </div>
   </div>
   <div class="table-responsive">
     <table class="table table-modern table-striped align-middle">
       <thead class="text-uppercase small text-muted">
         <tr>
           <th style="min-width: 180px;">As of</th>
+          <th>Mode</th>
           <th class="text-center">Proceed</th>
+          <th class="text-end">Orders</th>
+          <th class="text-end">Turnover %</th>
           <th class="text-end">Expected α (bps)</th>
           <th class="text-end">Costs (bps)</th>
           <th class="text-end">Net (bps)</th>
-          <th>Orders</th>
-          <th style="min-width: 200px;">Notes</th>
+          <th class="text-end">Equity</th>
+          <th class="text-end">Cash %</th>
+          <th style="min-width: 200px;">Reasons</th>
         </tr>
       </thead>
       <tbody>
         {% for ep in episodes %}
+        {% set gate = ep.get('gate', {}) or {} %}
+        {% set mode_code = gate.get('mode', 'paper') %}
+        {% if mode_code in ['live', 'realtime'] %}
+          {% set mode_label = 'Live' %}
+        {% elif mode_code in ['sim', 'simulated'] %}
+          {% set mode_label = 'Simulated' %}
+        {% else %}
+          {% set mode_label = 'Paper' %}
+        {% endif %}
+        {% set expected = gate.get('expected_alpha_bps', ep.get('expected_alpha_bps', 0)) | float %}
+        {% set cost = gate.get('cost_bps', ep.get('est_cost_bps', 0)) | float %}
+        {% set net = gate.get('net_bps', ep.get('net_edge_bps', 0)) | float %}
+        {% set turnover = gate.get('turnover_pct', 0) | float %}
+        {% set cash_frac = gate.get('cash_frac', 0) | float %}
+        {% set equity = gate.get('equity', 0) | float %}
+        {% set order_count = gate.get('order_count', ep.get('planned_orders_count', 0)) %}
+        {% set reasons_list = gate.get('reasons') if gate.get('reasons') else [] %}
+        {% if not reasons_list and ep.gate_reason %}
+          {% set reasons_list = [ep.gate_reason] %}
+        {% endif %}
+        {% set orders_submitted = ep.orders_submitted or [] %}
+        {% set traded = orders_submitted and orders_submitted[0] != 'DRY_RUN_NO_ORDERS' %}
+        {% set net_class = 'text-success' if net > 0 else ('text-danger' if net < 0 else '') %}
         <tr>
           <td>{{ ep.as_of }}</td>
+          <td>{{ mode_label }}</td>
           <td class="text-center">
-            {% if ep.proceed %}
-            <span class="status-pill"><i class="bi bi-check-circle"></i>Yes</span>
+            {% if gate.get('proceed') %}
+            <span class="status-pill"><i class="bi bi-check-circle"></i>Go</span>
             {% else %}
-            <span class="status-pill negative"><i class="bi bi-x-circle"></i>No</span>
+            <span class="status-pill negative"><i class="bi bi-x-circle"></i>Hold</span>
             {% endif %}
+            <div class="small text-muted mt-1">
+              {% if traded %}
+                Orders sent
+              {% elif ep.proceed %}
+                Proceeded
+              {% else %}
+                Skipped
+              {% endif %}
+            </div>
           </td>
-          <td class="text-end">{{ '%.2f'|format(ep.expected_alpha_bps|default(0)) }}</td>
-          <td class="text-end">{{ '%.2f'|format(ep.est_cost_bps|default(0)) }}</td>
-          <td class="text-end">{{ '%.2f'|format(ep.net_edge_bps|default(0)) }}</td>
-          <td>
-            {% if ep.orders_submitted %}
-              {{ ep.orders_submitted|length }} ids
+          <td class="text-end">{{ order_count }}</td>
+          <td class="text-end">{{ '%.1f'|format(turnover) }}%</td>
+          <td class="text-end">{{ '%.1f'|format(expected) }}</td>
+          <td class="text-end">{{ '%.1f'|format(cost) }}</td>
+          <td class="text-end"><span class="{{ net_class }}">{{ '%.1f'|format(net) }}</span></td>
+          <td class="text-end">{{ "${:,.0f}".format(equity) }}</td>
+          <td class="text-end">{{ '%.1f'|format(cash_frac * 100) }}%</td>
+          <td class="small">
+            {% if reasons_list %}
+              {{ reasons_list|join(', ') }}
             {% else %}
-              —
+              <span class="text-muted">—</span>
             {% endif %}
-          </td>
-          <td class="text-muted small">
-            {% set verdict = ep.get('risk_officer_verdict', {}) %}
-            {% set risk = ep.get('risk_officer', {}) %}
-            {% set note = verdict.message or risk.get('message') %}
-            {% if note %}
-              {{ note }}
-            {% elif verdict.approved %}
-              Risk officer: approved
-            {% elif risk.approved %}
-              Risk officer: {{ risk.approved }}
-            {% else %}
-              —
-            {% endif %}
-            {% if ep.rebalance_summary %}<br><span class="text-body">Δ {{ ep.rebalance_summary }}</span>{% endif %}
           </td>
         </tr>
         {% else %}
         <tr>
-          <td colspan="7" class="text-center text-muted py-4">No runs recorded yet.</td>
+          <td colspan="11" class="text-center text-muted py-4">No runs recorded yet.</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <div class="text-muted small">Page {{ page }}{% if total_pages %} / {{ total_pages }}{% endif %}</div>
+    <div class="d-flex gap-2">
+      {% if page > 1 %}
+        <a class="btn btn-outline-secondary" href="{{ url_for('log', page=page-1, limit=limit) }}">Previous</a>
+      {% endif %}
+      {% if has_more %}
+        <a class="btn btn-primary" href="{{ url_for('log', page=page+1, limit=limit) }}">Load more</a>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/v2/config.py
+++ b/v2/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 # ===== Canonical defaults =====
 
 # Automation & windows
@@ -35,7 +37,7 @@ MAX_WEIGHT_PER_NAME = 0.20
 TURNOVER_CAP = 0.35
 TARGET_POSITIONS = MAX_POSITIONS
 NAME_MAX = MAX_WEIGHT_PER_NAME
-VOL_TARGET_ANNUAL = 0.14
+VOL_TARGET_ANNUAL = float(os.getenv("VOL_TARGET_ANNUAL", "0.14"))
 TARGET_PORTFOLIO_VOL = VOL_TARGET_ANNUAL
 LAMBDA_RISK = 8.0
 TURNOVER_PENALTY = 0.0005
@@ -50,21 +52,22 @@ SLEEVE_WEIGHTS = {"xsec": 0.60, "event": 0.40}
 # Execution & costs
 ENABLE_COST_GATE = True
 DRY_RUN = False
-MIN_ORDER_NOTIONAL = 10.0
+MIN_ORDER_NOTIONAL = float(os.getenv("MIN_ORDER_NOTIONAL", "10"))
 MAX_SLICES = 5
 LIMIT_SLIP_BP = 10
 COST_SPREAD_BPS = 5.0
 COST_IMPACT_KAPPA = 0.10
 COST_IMPACT_PSI = 0.5
 FILL_TIMEOUT_SEC = 20
-MIN_NET_BPS_TO_TRADE = 0.0
+MIN_NET_BPS_TO_TRADE = float(os.getenv("MIN_NET_BPS_TO_TRADE", "0"))
 
 # Stops / TTL (stored; not auto-placed)
 ATR_STOP_MULT = 2.5
 TAKE_PROFIT_ATR = 2.0
 TIME_STOP_DAYS = 10
 
-# Paths
+# Paths & logging
+MAX_LOG_ROWS = int(os.getenv("MAX_LOG_ROWS", "5000"))
 EPISODES_PATH = "data/episodes_v2.jsonl"
 STATE_PATH = "data/state.json"
 SETTINGS_OVERRIDES_PATH = "data/settings_overrides.json"
@@ -72,3 +75,6 @@ SETTINGS_OVERRIDES_PATH = "data/settings_overrides.json"
 # API & model
 OPENAI_MODEL = "gpt-5"
 OPENAI_REASONING_EFFORT = "medium"
+
+# Execution cost heuristic
+COST_BPS_PER_1PCT_TURNOVER = float(os.getenv("COST_BPS_PER_1PCT_TURNOVER", "3.0"))


### PR DESCRIPTION
## Summary
- make cost/turnover gating configurable via env defaults and include richer gate metadata in each episode
- compute turnover-derived costs, onboarding overrides, and gate reason codes while persisting a detailed gate snapshot for the UI and CSV export
- expand the dashboard and log UI with status/portfolio/summary cards, paginated history, and CSV export backed by new web routes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e23f5731ec8331a7e882a834d2cd18