### PR TITLE
fix(engine+ui): honor TARGET_POSITIONS (≤10), fill to K, and log effective K

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -122,7 +122,7 @@
         <dt class="col-6 text-muted">Optimizer nonzero</dt>
         <dd class="col-6">{{ stage.get('optimizer_nonzero', 0) }}</dd>
         <dt class="col-6 text-muted">Target slots</dt>
-        <dd class="col-6">K {{ stage.get('target_positions', 0) }} · pre {{ stage.get('nonzero_pre_cap', stage.get('optimizer_nonzero', 0)) }} · post {{ stage.get('nonzero_post_cap', 0) }} · fill {{ stage.get('fill_count', 0) }} · gross {{ '%.2f'|format((stage.get('gross_final', 0) or 0)|float) }}</dd>
+        <dd class="col-6">Target K={{ stage.get('target_positions', 0) }} · Opt nonzero pre={{ stage.get('nonzero_pre', stage.get('optimizer_nonzero', 0)) }} · post={{ stage.get('nonzero_post', 0) }} · fill={{ stage.get('fill_count', 0) }} · gross={{ '%.2f'|format((stage.get('gross_final', 0) or 0)|float) }}</dd>
         <dt class="col-6 text-muted">Event scored</dt>
         <dd class="col-6">{{ stage.get('event_scored', 0) }}</dd>
         <dt class="col-6 text-muted">Filters removed</dt>

--- a/templates/log.html
+++ b/templates/log.html
@@ -172,7 +172,7 @@
           <td class="small">
             <div><span class="text-muted">Universe:</span> {{ stage.get('universe_count', 0) }} · Bars: {{ stage.get('symbols_with_bars', 0) }} · Features: {{ stage.get('valid_features', 0) }}</div>
             <div><span class="text-muted">Candidates:</span> {{ stage.get('candidates_topN', 0) }} · Opt nonzero: {{ stage.get('optimizer_nonzero', 0) }}</div>
-            <div><span class="text-muted">Target:</span> K {{ stage.get('target_positions', 0) }} · opt pre {{ stage.get('nonzero_pre_cap', stage.get('optimizer_nonzero', 0)) }} · post {{ stage.get('nonzero_post_cap', 0) }} · fill {{ stage.get('fill_count', 0) }} · gross {{ '%.2f'|format((stage.get('gross_final', 0) or 0)|float) }}</div>
+            <div><span class="text-muted">Target:</span> Target K={{ stage.get('target_positions', 0) }} · Opt nonzero pre={{ stage.get('nonzero_pre', stage.get('optimizer_nonzero', 0)) }} · post={{ stage.get('nonzero_post', 0) }} · fill={{ stage.get('fill_count', 0) }} · gross={{ '%.2f'|format((stage.get('gross_final', 0) or 0)|float) }}</div>
             {% set top = (diag.get('top_candidates') or [])[:3] %}
             {% if top %}
             <div><span class="text-muted">Top:</span> {% for item in top %}{{ item.get('symbol') }} ({{ '%.1f'|format(item.get('score', 0) | float) }}){% if not loop.last %}, {% endif %}{% endfor %}</div>

--- a/v2/config.py
+++ b/v2/config.py
@@ -32,9 +32,8 @@ EVENT_ALPHA_MULT = 1.00
 
 # Optimizer / risk
 ENABLE_VOL_TARGETING = True
-# Treat MAX_POSITIONS as legacy synonym; prefer TARGET_POSITIONS
 TARGET_POSITIONS = int(os.getenv("TARGET_POSITIONS", os.getenv("MAX_POSITIONS", "10")))
-MAX_POSITIONS = int(os.getenv("MAX_POSITIONS", str(TARGET_POSITIONS)))
+MAX_POSITIONS    = int(os.getenv("MAX_POSITIONS", str(TARGET_POSITIONS)))  # legacy synonym
 MAX_WEIGHT_PER_NAME = float(os.getenv("MAX_WEIGHT_PER_NAME", "0.20"))
 TURNOVER_CAP = float(os.getenv("TURNOVER_CAP", "0.35"))
 NAME_MAX = MAX_WEIGHT_PER_NAME

--- a/v2/orchestrator.py
+++ b/v2/orchestrator.py
@@ -291,85 +291,66 @@ def run_once() -> dict:
                 w_fb = w_fb / total_w
             w_scaled = w_fb
             fallback_used = True
-    diag["stage"]["fallback_used"] = bool(diag["stage"].get("fallback_used")) or fallback_used
+    diag_stage = diag.setdefault("stage", {})
+    diag_stage["fallback_used"] = bool(diag_stage.get("fallback_used")) or fallback_used
+    diag_stage["optimizer_nonzero"] = int(np.sum(np.abs(w_scaled) > 1e-6))
 
     target_weights = {s: float(w) for s, w in zip(candidates, w_scaled)}
 
-    diag_stage = diag.setdefault("stage", {})
     settings_dict = get_settings()
     target_slots = int(settings_dict.get("TARGET_POSITIONS", TARGET_POSITIONS))
     target_slots = max(1, min(10, target_slots))
     diag_stage["target_positions"] = target_slots
-    nonzero_pre = int(sum(1 for w in target_weights.values() if abs(w) > 1e-6))
-    diag_stage["nonzero_pre_cap"] = nonzero_pre
+    diag_stage["nonzero_pre"] = int(sum(1 for w in target_weights.values() if abs(w) > 1e-6))
 
-    if nonzero_pre > target_slots:
-        sorted_nonzero = sorted(
-            ((s, w) for s, w in target_weights.items() if abs(w) > 1e-6),
-            key=lambda kv: abs(kv[1]),
-            reverse=True,
+    if len(target_weights) > target_slots:
+        target_weights = dict(
+            sorted(target_weights.items(), key=lambda kv: abs(kv[1]), reverse=True)[:target_slots]
         )
-        keep_symbols = {s for s, _ in sorted_nonzero[:target_slots]}
-        target_weights = {s: (w if s in keep_symbols else 0.0) for s, w in target_weights.items()}
-
-    try:
-        name_cap = float(getattr(cfg, "NAME_MAX", MAX_WEIGHT_PER_NAME))
-    except Exception:
-        name_cap = float(MAX_WEIGHT_PER_NAME)
 
     fill_count = 0
     nonzero_syms = [s for s, w in target_weights.items() if abs(w) > 1e-6]
-    max_fillable = min(target_slots, len(ranked_symbols))
-    if len(nonzero_syms) < max_fillable:
-        need = max(0, target_slots - len(nonzero_syms))
-        fill_candidates = [
-            sym for sym in ranked_symbols if abs(target_weights.get(sym, 0.0)) <= 1e-6
-        ][:need]
-        if fill_candidates:
-            current_gross = sum(abs(w) for w in target_weights.values())
-            target_gross = min(1.0, max(GROSS_EXPOSURE_FLOOR, current_gross))
-            available = max(0.0, target_gross - current_gross)
-            per_weight = min(name_cap, available / max(len(fill_candidates), 1))
-            for sym in fill_candidates:
-                if sym not in target_weights:
-                    target_weights[sym] = 0.0
-                if abs(target_weights.get(sym, 0.0)) <= 1e-6:
-                    target_weights[sym] = max(0.0, min(per_weight, name_cap))
+    if len(nonzero_syms) < min(target_slots, len(ranked_symbols)):
+        need = target_slots - len(nonzero_syms)
+        fill_syms = [sym for sym in ranked_symbols if sym not in target_weights][:need] if need > 0 else []
+        if fill_syms:
+            gross_now = sum(abs(w) for w in target_weights.values())
+            room = max(0.0, 1.0 - gross_now)
+            try:
+                cap_weight = float(settings_dict.get("MAX_WEIGHT_PER_NAME", MAX_WEIGHT_PER_NAME))
+            except (TypeError, ValueError):
+                cap_weight = float(MAX_WEIGHT_PER_NAME)
+            add_w = 0.0 if len(fill_syms) == 0 else min(room / len(fill_syms), cap_weight)
+            for sym in fill_syms:
+                if add_w <= 0:
+                    break
+                target_weights[sym] = min(cap_weight, add_w)
                 fill_count += 1
 
-    active_weights = {s: w for s, w in target_weights.items() if abs(w) > 1e-6}
-    if isinstance(active_weights, dict) and len(active_weights) > target_slots:
-        sorted_active = sorted(active_weights.items(), key=lambda kv: abs(kv[1]), reverse=True)
-        active_weights = dict(sorted_active[:target_slots])
+    try:
+        cap_weight = float(settings_dict.get("MAX_WEIGHT_PER_NAME", MAX_WEIGHT_PER_NAME))
+    except (TypeError, ValueError):
+        cap_weight = float(MAX_WEIGHT_PER_NAME)
 
-    gross = sum(abs(w) for w in active_weights.values())
+    target_weights = {
+        s: max(-cap_weight, min(cap_weight, float(w))) for s, w in target_weights.items()
+    }
+
+    gross = sum(abs(w) for w in target_weights.values())
     if gross > 0 and gross < GROSS_EXPOSURE_FLOOR:
-        scale = min(GROSS_EXPOSURE_FLOOR / max(gross, 1e-9), 1.0)
-        active_weights = {s: w * scale for s, w in active_weights.items()}
+        scale = min(GROSS_EXPOSURE_FLOOR / gross, 1.0)
+        target_weights = {s: max(-cap_weight, min(cap_weight, w * scale)) for s, w in target_weights.items()}
+        gross = sum(abs(w) for w in target_weights.values())
 
-        try:
-            active_weights = {s: max(min(w, name_cap), 0.0) for s, w in active_weights.items()}
-            gross2 = sum(abs(w) for w in active_weights.values())
-            if gross2 > 1.0 and gross2 > 0:
-                active_weights = {s: w / gross2 for s, w in active_weights.items()}
-        except Exception:
-            pass
+    if gross > 1.0 and gross > 0:
+        target_weights = {s: w / gross for s, w in target_weights.items()}
+        gross = sum(abs(w) for w in target_weights.values())
 
-    target_weights = {s: active_weights.get(s, 0.0) for s in target_weights.keys()}
-    gross_final = sum(abs(w) for w in target_weights.values())
-    if gross_final > 1.0 and gross_final > 0:
-        target_weights = {s: w / gross_final for s, w in target_weights.items()}
-        gross_final = sum(abs(w) for w in target_weights.values())
-
-    diag_stage["nonzero_post_cap"] = int(sum(1 for w in target_weights.values() if abs(w) > 1e-6))
+    diag_stage["nonzero_post"] = int(sum(1 for w in target_weights.values() if abs(w) > 1e-6))
     diag_stage["fill_count"] = int(fill_count)
-    diag_stage["gross_final"] = round(gross_final, 4)
-    diag_stage["gross_after_floor"] = diag_stage["gross_final"]
-    diag_stage["names_after_cap"] = diag_stage["nonzero_post_cap"]
+    diag_stage["gross_final"] = round(gross, 4)
 
     w_final = np.array([target_weights.get(s, 0.0) for s in candidates], dtype=float)
-
-    diag["stage"]["optimizer_nonzero"] = int(sum(1 for w in target_weights.values() if abs(w) > 1e-6))
     diag["exposure"] = {
         "sum_abs_weights": float(sum(abs(w) for w in target_weights.values())),
         "vol_target": float(VOL_TARGET_ANNUAL),

--- a/v2/settings_bridge.py
+++ b/v2/settings_bridge.py
@@ -24,7 +24,15 @@ ALLOWED_KEYS = [
 def _normalize_settings(values: Dict[str, Any]) -> Dict[str, Any]:
     data = dict(values or {})
     if "TARGET_POSITIONS" not in data and "MAX_POSITIONS" in data:
-        data["TARGET_POSITIONS"] = data["MAX_POSITIONS"]
+        try:
+            data["TARGET_POSITIONS"] = int(data["MAX_POSITIONS"])
+        except (TypeError, ValueError):
+            data["TARGET_POSITIONS"] = data["MAX_POSITIONS"]
+    if "TARGET_POSITIONS" in data:
+        try:
+            data["TARGET_POSITIONS"] = int(data["TARGET_POSITIONS"])
+        except (TypeError, ValueError):
+            pass
     return data
 
 

--- a/webapp.py
+++ b/webapp.py
@@ -703,7 +703,9 @@ def settings():
         data["NAME_MAX"]             = float(g("NAME_MAX", "0.20"))
         data["SECTOR_MAX"]           = float(g("SECTOR_MAX", "0.30"))
         data["REBALANCE_BAND"]       = float(g("REBALANCE_BAND", "0.25"))
-        data["TARGET_POSITIONS"]     = int(g("TARGET_POSITIONS", "10"))
+        tp = g("TARGET_POSITIONS")
+        if tp is not None and tp != "":
+            data["TARGET_POSITIONS"] = int(tp)
         val_max_positions = g("MAX_POSITIONS")
         if val_max_positions is not None and val_max_positions != "":
             data["MAX_POSITIONS"] = int(val_max_positions)


### PR DESCRIPTION
## Summary
- align TARGET_POSITIONS defaults with MAX_POSITIONS legacy overrides and normalize persisted settings values
- update the settings form handling to write TARGET_POSITIONS and teach the engine to clamp/fill weights to the configured K while respecting caps and gross exposure limits
- extend dashboard/log diagnostics to show the effective Target K inputs and fill statistics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e68bc056408331a685af444ac02303